### PR TITLE
Feature/lab display name

### DIFF
--- a/Task.js
+++ b/Task.js
@@ -134,6 +134,7 @@ class Task extends Unit {
       isAssesment: false,
       assets_path: assets_path,
       lab: lab_data.lab,
+      lab_display_name: lab_data.lab_display_name,
       broadArea: lab_data.broadArea,
       deployLab: lab_data.deployLab,
       phase: lab_data.phase,

--- a/exp.v1.js
+++ b/exp.v1.js
@@ -75,6 +75,7 @@ if (require.main === module) {
     default_lab_data.collegeName = match.groups.devInstituteName.toUpperCase();
     default_lab_data.phase = 'Testing';
     default_lab_data.lab = 'Virtual Lab';
+    default_lab_data.lab_display_name = 'Virtual Lab Display Name';
     default_lab_data.broadArea = { name : 'Test'};
   } else {
     console.log('No match found');

--- a/lab-descriptor-instructions.md
+++ b/lab-descriptor-instructions.md
@@ -26,7 +26,7 @@ Lab Display Name: This name will be displayed on the Lab web pages as the Lab na
 
 Phase: Should be the number of the phase that the lab belongs to, e.g. Phase 3 or Phase 4
 	
-Deploy: This should be true if we are hosting a lab along with experiments or only a lab but no experiments. If we want to host only experiments without rehosting the lab then it should be false. This may be useful in cases where the lab developer makes a fix in the lab and only wants to rehost the lab without rehosting all the experiments with it or in cases where the lab developer has changed something on an experiment and the complete lab need not be rehosted.
+Deploy Lab: This should be true if we are hosting a lab along with experiments or only a lab but no experiments. If we want to host only experiments without rehosting the lab then it should be false. This may be useful in cases where the lab developer makes a fix in the lab and only wants to rehost the lab without rehosting all the experiments with it or in cases where the lab developer has changed something on an experiment and the complete lab need not be rehosted.
 	
 College Name(Institute Name): Update from the R0 file (which is given in the request for hosting issue)
 

--- a/lab-descriptor-instructions.md
+++ b/lab-descriptor-instructions.md
@@ -20,11 +20,13 @@
 			- Design Engineering
 			- Aerospace Engineering
 
-Lab Name: Should be same in the JSON file, GitHub repo name, and in /var/www/html/
+Lab Name: Should be same in the JSON file, GitHub repo name, and in /var/www/html/. This name acts as the lab identifier and hence must be unique across all labs and cannot be changed once given.
 
-Phase: Should be the number that the lab belongs to Phase 3 or so
+Lab Display Name: This name will be displayed on the Lab web pages as the Lab name. This must be unique across all the labs but it can be changed later as long as another unique name is chosen.
+
+Phase: Should be the number of the phase that the lab belongs to, e.g. Phase 3 or Phase 4
 	
-Deploy: This should be true if we are hosting a lab and exp or only a lab. If we want to host the only exp then it should be false
+Deploy: This should be true if we are hosting a lab along with experiments or only a lab but no experiments. If we want to host only experiments without rehosting the lab then it should be false. This may be useful in cases where the lab developer makes a fix in the lab and only wants to rehost the lab without rehosting all the experiments with it or in cases where the lab developer has changed something on an experiment and the complete lab need not be rehosted.
 	
 College Name(Institute Name): Update from the R0 file (which is given in the request for hosting issue)
 

--- a/lab-descriptor.json
+++ b/lab-descriptor.json
@@ -4,6 +4,7 @@
         "link": ""
     },
     "lab": "",
+	"lab_display_name": "",
     "deployLab": ,
     "phase": ,
     "collegeName": "",

--- a/labDescSchema.json
+++ b/labDescSchema.json
@@ -1,11 +1,12 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
-    "required": ["lab", "broadArea", "phase", "collegeName",
+    "required": ["lab", "lab_display_name", "broadArea", "phase", "collegeName",
 		 "baseUrl", "introduction", "objective",
 		 "targetAudience", "courseAlignment"],
     "properties": {
 	"lab": {"type": "string"},
+	"lab_display_name": {"type": "string"},
 	"broadArea": {
 	    "type": "object",
 	    "properties": {

--- a/page-templates/lab-name.handlebars
+++ b/page-templates/lab-name.handlebars
@@ -1,1 +1,1 @@
-<h2 class="text-center">{{ lab }}</h2>
+<h2 class="text-center">{{ lab_display_name }}</h2>

--- a/templates/partials/breadcrumbs.handlebars
+++ b/templates/partials/breadcrumbs.handlebars
@@ -8,7 +8,7 @@
       <i aria-hidden="true" class="fa fa-angle-right"></i>
     </span>
     <a href="https://{{baseUrl}}"> 
-    {{lab}}
+    {{lab_display_name}}
     </a>
     <span class="mx-2">
       <i aria-hidden="true" class="fa fa-angle-right"></i>

--- a/templates/partials/lab-breadcrumbs.handlebars
+++ b/templates/partials/lab-breadcrumbs.handlebars
@@ -8,7 +8,7 @@
       <i aria-hidden="true" class="fa fa-angle-right"></i>
     </span>
     <a href="https://{{baseUrl}}"> 
-    {{lab}}
+    {{lab_display_name}}
     </a>
     <span class="mx-2">
       <i aria-hidden="true" class="fa fa-angle-right"></i>


### PR DESCRIPTION
This pull request merges changes for the Lab Display Name feature into the master branch.
This feature introduces a new lab-descriptor field lab-display-name. This is a mandatory field.
The idea behind keeping it a mandatory field is that the lab name should be considered and treated as the immutable lab identifier. Hence it is better to make the lab display name an explicit and separate variable, which is unique but can be changed as required.